### PR TITLE
Small fix: for testing, map data to device while loading a checkpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def test(
             raise ValueError(f"Unknown classifier variant: {classifier}")
 
     # Load the model checkpoints
-    model.load_state_dict(torch.load(checkpoints, weights_only=True))
+    model.load_state_dict(torch.load(checkpoints, weights_only=True, map_location=device))
 
     # Load the dataset
     dataset = WildfireDataset("test")


### PR DESCRIPTION
Steps to reproduce:
1. Use resources without CUDA (e.g. google colab with CPU / locally on pc)
2. `python main.py test --classifier resnext --checkpoints resnext.pth `

Error: 
```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```