### PR TITLE
Small fix: save checkpoints during training for small number of epochs

### DIFF
--- a/wildfire_prediction/train/classifier.py
+++ b/wildfire_prediction/train/classifier.py
@@ -58,7 +58,8 @@ def train_classifier(
         results.append_log(log_file)
 
         # Save the model checkpoints every 20% of the epochs
-        if i % (epochs // 5) == 0:
+        checkpoint_frequency = max(epochs // 5, 1)
+        if i % checkpoint_frequency == 0:
             torch.save(classifier.state_dict(), f"classifier-{i}-{epochs}.pth")
 
     # Save the final model


### PR DESCRIPTION
Fix of a small bug if the number of epochs is less than 5, e.g.:
`!python main.py train --classifier resnext --epochs 3 --learning-rate 0.0001 --batch-size 128`

Error:
```
Traceback (most recent call last):
  File "/content/Wildfire-Prediction/main.py", line 139, in <module>
    main()
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/content/Wildfire-Prediction/main.py", line 110, in train
    train_classifier(model, train_loader, test_loader, epochs, learning_rate, device)
  File "/content/Wildfire-Prediction/wildfire_prediction/train/classifier.py", line 61, in train_classifier
    if i % (epochs // 5) == 0:
       ~~^~~~~~~~~~~~~~~
ZeroDivisionError: integer modulo by zero
```